### PR TITLE
feat: Upgrade microsatellite version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ For now, you'll need to add this repo as a buildpack to your application. We'll 
 Configure this buildpack by setting configuration variables for your app. At minimum, you must set:
 - `COLLECTOR_SATELLITE_KEY`: the satellite requires this to function.
 - `COLLECTOR_PLAIN_PORT`: the satellite tries to bind to port 80 by default, which will not work with Heroku.
+- `COLLECTOR_SATELLITE_TYPE_FLAVOR`: **Required** Must be set to `micro`
+- `COLLECTOR_SAMPLE_ONE_IN_N`: **Required** Must be set to to a sampling value. Set to `1` to sample all traces.
 
 Additional configuration variables can be found [in LightStep's documentation](https://docs.lightstep.com/docs/docker-install-and-configure-satellites).
 

--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,7 @@ BUILDPACK_DIR=$(cd "$(dirname "$0")"; cd ..; pwd)
 LS_DIR="$BUILD_DIR/.lightstep-collector"
 PROFILE_DIR="$BUILD_DIR/.profile.d"
 
-VERSION="2021.03.22.13.16.05Z"
+VERSION="2021.10.27.20.01.38Z"
 CACHED_VERSION="$CACHE_DIR/lightstep-collector-$VERSION"
 
 arrow() {
@@ -24,7 +24,7 @@ if [ ! -d "$CACHED_VERSION" ]; then
     -O lightstep-collector.deb \
     --quiet \
     --content-disposition \
-    https://packagecloud.io/lightstep/collector/packages/ubuntu/bionic/lightstep-collector_${VERSION}_amd64.deb/download.deb
+    https://packagecloud.io/lightstep/microsatellite/packages/ubuntu/bionic/lightstep-collector_${VERSION}_amd64.deb/download.deb
 
   dpkg -x lightstep-collector.deb "$CACHED_VERSION"
 else


### PR DESCRIPTION
This time I know what I am doing! 

The current satellites in Heroku production are running in microsatellite mode, I missed one configuration option `SAMPLED_1_IN_N`, which is required in addition the satellite type. 